### PR TITLE
[WEB-3968] Replace inconsistent naming of test reports

### DIFF
--- a/src/app/components/app-footer/app-footer.component.html
+++ b/src/app/components/app-footer/app-footer.component.html
@@ -1,7 +1,7 @@
 <section class="app-footer">
   <div class="logo" [inlineSVG]="'/assets/images/footer/bitrise-icon.svg'"></div>
   <div class="text">
-    Test reports
+    Test Reports
     <br>
     an official Bitrise add-on
   </div>

--- a/src/app/components/app-footer/app-footer.component.html
+++ b/src/app/components/app-footer/app-footer.component.html
@@ -1,7 +1,7 @@
 <section class="app-footer">
   <div class="logo" [inlineSVG]="'/assets/images/footer/bitrise-icon.svg'"></div>
   <div class="text">
-    Testing reports
+    Test reports
     <br>
     an official Bitrise add-on
   </div>

--- a/src/app/components/test-summary/test-summary.component.html
+++ b/src/app/components/test-summary/test-summary.component.html
@@ -3,8 +3,8 @@
   <bitrise-loader-circle [show]="loading$ | async"></bitrise-loader-circle>
   <div class="notification-wrapper" *ngIf="!(loading$ | async) && !testReports.length">
       <bitrise-notification type="warning">
-      Testing add-on wasn't configured correctly. Please make sure you configure it in the Workflow Editor.
-      <a href="https://devcenter.bitrise.io/testing/test-reports/" target="_blank">Get help for setting up Testing add-on.</a>
+      Test Reports wasn't configured correctly. Please make sure you configure it in the Workflow Editor.
+      <a href="https://devcenter.bitrise.io/testing/test-reports/" target="_blank">Get help for setting up Test Reports.</a>
     </bitrise-notification>
   </div>
   <bitrise-test-report

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Test add-on</title>
+    <title>Test Reports</title>
     <base href="/" />
     <meta name="viewport" content="viewport-fit=cover,width=device-width,minimum-scale=1,initial-scale=1" />
     <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
Use 'Test Reports' instead of testing addon, testing, test addon